### PR TITLE
Feature/remove examples from ressourcescasusages

### DIFF
--- a/input/pagecontent/ressources_casusage.md
+++ b/input/pagecontent/ressources_casusage.md
@@ -5,14 +5,14 @@ Liste des ressources à utiliser par cas d'usage
 Liste des ressources (profils,paramètres de recherche, terminologies, exemples) à utiliser dans le cadre du cas d'usage PS à titre individuel (y compris les ressources communes aux autres cas d'usage)
 
 {% sql SELECT '[' || Id ||']('||Type||'-' || id || '.html)' as "Id", Type, IFNULL(Description,' ') as "Description" from Resources
-where Id not like '%sos%' and  Id not like '%cpts%' and Id not like 'Example%'and Type != 'ImplementationGuide' %}
+where Id not like '%sos%' and  Id not like '%cpts%' and Id not like 'Example%'nd Id not like 'Example%'and Type in  ('StructureDefinition', 'ValueSet', 'SearchParameter') %}
 
 ### CPTS
 
 Liste des ressources (profils,paramètres de recherche, terminologies, exemples) à utiliser dans le cadre du cas d'usage CPTS
 
 {% sql SELECT '[' || Id ||']('||Type||'-' || id || '.html)' as "Id", Type, IFNULL(Description,' ') as "Description" from Resources
-where Id like '%cpts%'and Id not like 'Example%' %}
+where Id like '%cpts%'and Id not like 'Example%' and Type in  ('StructureDefinition', 'ValueSet', 'SearchParameter') %}
 
 ### SOS Médecins
 

--- a/input/pagecontent/ressources_casusage.md
+++ b/input/pagecontent/ressources_casusage.md
@@ -5,7 +5,7 @@ Liste des ressources à utiliser par cas d'usage
 Liste des ressources (profils,paramètres de recherche, terminologies, exemples) à utiliser dans le cadre du cas d'usage PS à titre individuel (y compris les ressources communes aux autres cas d'usage)
 
 {% sql SELECT '[' || Id ||']('||Type||'-' || id || '.html)' as "Id", Type, IFNULL(Description,' ') as "Description" from Resources
-where Id not like '%sos%' and  Id not like '%cpts%' and Id not like 'Example%'nd Id not like 'Example%'and Type in  ('StructureDefinition', 'ValueSet', 'SearchParameter') %}
+where Id not like '%sos%' and  Id not like '%cpts%' and Id not like 'Example%' and Type in ('StructureDefinition', 'ValueSet', 'SearchParameter') %}
 
 ### CPTS
 


### PR DESCRIPTION
## Description des changements

* Modif requete SQL pour n'afficher que les profiles, les ValueSet et les search param. Les ressources exemples ne sont pas affichées

## Preview

https://ansforge.github.io/IG-fhir-service-acces-aux-soins/feature/remove-examples-from-ressourcescasusages/ig
