### PR TITLE
Update fhir-release.yml

### DIFF
--- a/.github/workflows/fhir-release.yml
+++ b/.github/workflows/fhir-release.yml
@@ -31,4 +31,3 @@ jobs:
           publish_repo: "ansforge/IG-website-release"
           publish_repo_token :  ${{ secrets.ANS_IG_API_TOKEN }} 
           publish_path_outpout : "./IG-website-release/www/ig/fhir"
-          ig-publisher-version: 1.6.20


### PR DESCRIPTION
## Description des changements
Suppression de la version de l'IG publisher 
          ig-publisher-version: 1.6.20


## Preview

https://ansforge.github.io/IG-fhir-service-acces-aux-soins/[ajouter_nom_de_la_branche]/ig
