### PR TITLE
feat: passage au template 2 (dépendances multi-version FRCore)

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -3,7 +3,7 @@
 # see comments below for instructions
 
 ig = fsh-generated/resources/ImplementationGuide-ans.fhir.fr.sas.json
-#template = https://github.com/ansforge/IG-template/tree/version-historique
+template = https://github.com/ansforge/IG-template/tree/version-historique
 #template = https://github.com/ansforge/IG-template
 #template = #local-template
 

--- a/ig.ini
+++ b/ig.ini
@@ -3,7 +3,8 @@
 # see comments below for instructions
 
 ig = fsh-generated/resources/ImplementationGuide-ans.fhir.fr.sas.json
-template = https://github.com/ansforge/IG-template
+#template = https://github.com/ansforge/IG-template/tree/version-historique
+#template = https://github.com/ansforge/IG-template
 #template = #local-template
 
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,8 +21,8 @@ parameters:
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
 dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
-  v220@npm:hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
-  hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
+  hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
+  hl7.fhir.fr.core#v110@npm:hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
 
 pages:
     index.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,8 +21,8 @@ parameters:
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
 dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
-  hl7.fhir.fr.core: 2.1.0 #Version utilisée pour les nouveaux cas d'usage
-  v110@npm:hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
+  v210@npm:hl7.fhir.fr.core: 2.1.0 #Version utilisée pour les nouveaux cas d'usage
+  hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
 
 pages:
     index.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,7 +21,7 @@ parameters:
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
 dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
-  v210@npm:hl7.fhir.fr.core: 2.1.0 #Version utilisée pour les nouveaux cas d'usage
+  v220@npm:hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
   hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
 
 pages:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,7 +21,8 @@ parameters:
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
 dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
-  hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
+  #v220@npm:hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
+  hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
 
 pages:
     index.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,7 +16,7 @@ jurisdiction: urn:iso:std:iso:3166#FR "France (la)"
 
 parameters:
   shownav: 'true'
-  i18n-default-lang: fr-FR # Default language
+  i18n-default-lang: fr # Default language
   apply-jurisdiction: true
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,8 +21,7 @@ parameters:
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
 dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
-  v220@npm:hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
-  hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
+  hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
 
 pages:
     index.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -20,19 +20,9 @@ parameters:
   apply-jurisdiction: true
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
-
-    
-dependencies:
-    hl7.fhir.fr.core:
-     id: frcore210
-     version: 2.1.0
-     reason: |
-      Version utilisée pour les nouveaux cas d'usage
-    v110@npm:hl7.fhir.fr.core: 
-     id: frcore110
-     version: 1.1.0
-     reason: |
-      Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
+dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
+  hl7.fhir.fr.core: 2.1.0 #Version utilisée pour les nouveaux cas d'usage
+  v110@npm:hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
 
 pages:
     index.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,8 +21,16 @@ parameters:
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
 dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
-  hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
-  hl7.fhir.fr.core#v110@npm:hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
+    hl7.fhir.fr.core:
+     id: frcore210
+     version: 2.1.0
+     reason: |
+      Version utilisée pour les nouveaux cas d'usage
+    v110@npm:hl7.fhir.fr.core: 
+     id: frcore110
+     version: 1.1.0
+     reason: |
+      Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
 
 pages:
     index.md:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -21,7 +21,7 @@ parameters:
   path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
 
 dependencies: # https://build.fhir.org/ig/FHIR/ig-guidance/versions.html#depending-on-multiple-different-versions-of-the-same-package
-  #v220@npm:hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
+  v220@npm:hl7.fhir.fr.core: 2.2.0 #Version utilisée pour les nouveaux cas d'usage
   hl7.fhir.fr.core: 1.1.0 #Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
 
 pages:


### PR DESCRIPTION
## Description des changements

Ce PR explore l'ajout d'une dépendance multi-version sur \`hl7.fhir.fr.core\` dans le \`sushi-config.yaml\`, afin de gérer la coexistence de la version 1.1.0 (cas d'usage PS Indiv, SOS, CPTS) et 2.2.0 (nouveaux cas d'usage) via la syntaxe npm alias supportée par SUSHI.

**⚠️ Statut : bloqué — bug dans l'IG Publisher, voir analyse ci-dessous.**

---

## Bug identifié : `Publishing Content Failed: Name 'hl7.fhir.fr.core' already exists`

### Cause racine

Le publisher génère des paquets NPM de langue (ex. \`.fr.tgz\`) quand le template ANS est utilisé, car ce dernier positionne \`"multilanguage-format": true\` dans son \`config.json\`. Pour ce faire, il crée une copie interne de l'\`ImplementationGuide\` via \`copyToLanguage()\`.

Le mécanisme anti-doublon du publisher repose sur un flag en mémoire (\`IG_DEP_ALIASED\`, stocké dans \`UserData\`) positionné sur les éléments de dépendance aliasés. Ce flag **n'est pas préservé lors d'un \`copy()\`** (les \`UserData\` Java sont \`transient\` par défaut).

Résultat : la copie pour le paquet de langue ne contient plus le flag → les deux dépendances \`hl7.fhir.fr.core\` sont ajoutées avec le même nom dans le \`package.json\` → \`JsonException\`.

### Chemin d'exécution (publisher 2.1.2, `PublisherIGLoader.java`)

```
l.2002 : IG_DEP_ALIASED positionné sur pf.publishedIg           ✓
l.2285 : NPMPackageGenerator(pf.publishedIg)      → succès      ✓
l.2269 : vig = copyToLanguage(pf.publishedIg)     → flag perdu  ✗
l.2271 : NPMPackageGenerator(vig)                 → JsonException: Name 'hl7.fhir.fr.core' already exists ✗
```

Stack trace observée :
```
org.hl7.fhir.utilities.json.JsonException: Name 'ans.fhir.fr.mesures' already exists (value = "3.2.0")
    at NPMPackageGenerator.buildPackageJson(NPMPackageGenerator.java:273)
    at NPMPackageGenerator.<init>(NPMPackageGenerator.java:150)
    at PublisherIGLoader.load(PublisherIGLoader.java:2271)
```

### Versions affectées

Toutes les versions testées : **2.0.29, 2.1.2, 2.2.7, 2.2.8**. Le bug est présent dans toutes les versions publiées à ce jour.

---

## Propositions de fix

### Fix 1 — HL7/fhir-ig-publisher (fix définitif)

Après chaque \`copyToLanguage()\` / \`publishedIg.copy()\` utilisé pour générer des variantes de paquets NPM, re-propager le flag :

```java
// Re-apply IG_DEP_ALIASED flags lost during copy (UserData is transient)
List<ImplementationGuide.ImplementationGuideDependsOnComponent> origDeps = pf.publishedIg.getDependsOn();
List<ImplementationGuide.ImplementationGuideDependsOnComponent> vigDeps = vig.getDependsOn();
for (int i = 0; i < Math.min(origDeps.size(), vigDeps.size()); i++) {
  if (origDeps.get(i).getPackageIdElement().hasUserData(UserDataNames.IG_DEP_ALIASED)) {
    vigDeps.get(i).getPackageIdElement().setUserData(UserDataNames.IG_DEP_ALIASED, true);
  }
}
```

À appliquer aux deux endroits concernés dans `load()` : la boucle \`generateVersions\` (l.2287) et la boucle \`allLangs()\` (l.2292).

### Fix 2 — ansforge/IG-template (contournement rapide)

Passer \`"multilanguage-format": false\` dans \`config.json\`. Cela court-circuite la génération des paquets NPM de langue et donc le code défaillant. Le paramètre \`i18n-default-lang\` reste fonctionnel indépendamment pour le rendu en français.

---

## Preview

https://ansforge.github.io/IG-fhir-service-acces-aux-soins/nriss-patch-1/ig