### PR TITLE
Update sushi-config.yaml

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -27,11 +27,7 @@ translation-sources:
 
  
 dependencies:
-    v110@npm:hl7.fhir.fr.core: 
-     id: frcore110
-     version: 1.1.0
-     reason: |
-      Version utilisée pour les cas d'usage PS Indiv, SOS et CPTS
+    hl7.fhir.fr.core: 1.1.0
 
 pages:
     index.md:


### PR DESCRIPTION
## Description des changements

Suppression de l'appel à l'"alias" frcore qui posait des problèmes dans le validateur Inferno
